### PR TITLE
Remove double defined cff in ICESHELF and ICESHELF_3EQ case

### DIFF
--- a/ROMS/Nonlinear/set_vbc.F
+++ b/ROMS/Nonlinear/set_vbc.F
@@ -377,7 +377,7 @@
 # ifdef ICESHELF
 
 #  ifdef ICESHELF_3EQ
-      real(r8) :: Hscale, Hlice, uStar, gturb, cff
+      real(r8) :: Hscale, Hlice, uStar, gturb
       real(r8) :: salt_b, temp_b, melt_rate
 #  endif
 


### PR DESCRIPTION
cff is initialized in the next section (line 395-398).